### PR TITLE
Test for keys in map-with-keys predicate.

### DIFF
--- a/src/active/data/realm.cljc
+++ b/src/active/data/realm.cljc
@@ -364,6 +364,16 @@ The two-argument version can be called as follows:
      realm-records/predicate set?
      realm-records/metadata {})))
 
+(defn- map-with-keys-predicate [keys-realm-map]
+  (let [key? (set (keys keys-realm-map))
+        required-keys (->> keys-realm-map
+                           (remove #(contains? (second %) nil))
+                           (map first))]
+    (fn [x]
+      (and (map? x)
+           (every? #(core/contains? x %) required-keys)
+           (every? key? (keys x))))))
+
 (defn map-with-keys
   "Create realm containing certain keys and a different realm for the value associated with each key.
 
@@ -381,7 +391,7 @@ The two-argument version can be called as follows:
                                                            keys-realm-map))
                                     "}")
      realm-records/map-with-keys-realm-map keys-realm-map
-     realm-records/predicate map?
+     realm-records/predicate (map-with-keys-predicate keys-realm-map)
      realm-records/metadata {})))
 
 (defn map-of

--- a/src/active/data/realm/schema.cljc
+++ b/src/active/data/realm/schema.cljc
@@ -132,7 +132,8 @@
    realm-inspection/map-with-keys
    (into {}
          (map (fn [[key realm]]
-                (if (realm-inspection/optional? realm)
+                ;; i.e. (realm/contains? realm nil)
+                (if ((realm-inspection/predicate realm) nil)
                   ;; make both keys and value optional - (:key {}) == (:key {:key nil})
                   [(schema/optional-key key)
                    (schema realm)]

--- a/test/active/data/realm_test.cljc
+++ b/test/active/data/realm_test.cljc
@@ -239,7 +239,8 @@
 
   (is ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) {:foo 5 :bar "5"}))
   (is ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) {:foo "5" :bar 5}))
-  (is ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) {:bla 5 :baz "5"}))
+  (is ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar (realm/optional realm/string)})) {:foo "5"}))
+  (is (not ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) {:bla 5 :baz "5"})))
   (is (not ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) 5)))
   (is (not ((realm-inspection/predicate (realm/map-with-keys {:foo realm/integer :bar realm/string})) [])))
 


### PR DESCRIPTION
This better corresponds to the generated schema, and better checks.